### PR TITLE
fix: suppress IL2087 for AOT compilation

### DIFF
--- a/exe/generate-avatar.cs
+++ b/exe/generate-avatar.cs
@@ -3,7 +3,7 @@
 #:project ../Source/TimeWarp.Multiavatar/TimeWarp.Multiavatar.csproj
 #:project ../Source/TimeWarp.Amuru/TimeWarp.Amuru.csproj
 #:property TrimMode=partial
-#:property NoWarn=IL2104;IL3053
+#:property NoWarn=IL2104;IL3053;IL2087
 
 using System.Security.Cryptography;
 using System.Text;


### PR DESCRIPTION
## Summary
- Add IL2087 to NoWarn in generate-avatar.cs
- Fixes AOT compilation errors in CI/CD

## Problem
The MockSetup.Throws method in TimeWarp.Amuru uses Activator.CreateInstance which triggers trim analysis warnings during AOT compilation.

## Solution  
Suppress IL2087 warning in the executable script since the testing code doesn't affect runtime behavior.

## Test plan
- [x] Local AOT publish works without errors
- [ ] CI/CD workflow completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)