### PR TITLE
Fix cross-run artifact downloads in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -260,12 +260,27 @@ jobs:
           echo "sha=$SHA" >> $GITHUB_OUTPUT
           echo "Release tag ${{ github.event.release.tag_name }} points to commit $SHA"
 
+      - name: Find workflow run for commit
+        id: find-run
+        run: |
+          RUN_ID=$(gh api /repos/${{ github.repository }}/actions/runs \
+            -f event=push \
+            -f status=completed \
+            --jq ".workflow_runs[] | select(.head_sha == \"${{ steps.get-sha.outputs.sha }}\") | .id" \
+            | head -1)
+          echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
+          echo "Found workflow run ID: $RUN_ID for commit ${{ steps.get-sha.outputs.sha }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download executables artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: executables-${{ steps.get-sha.outputs.sha }}-*
           path: artifacts/executables
           merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.find-run.outputs.run-id }}
 
       - name: Download installer artifacts
         uses: actions/download-artifact@v4
@@ -273,12 +288,16 @@ jobs:
           pattern: installer-${{ steps.get-sha.outputs.sha }}-*
           path: artifacts/installer
           merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.find-run.outputs.run-id }}
 
       - name: Download package artifacts
         uses: actions/download-artifact@v4
         with:
           name: packages-${{ steps.get-sha.outputs.sha }}
           path: artifacts/packages
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.find-run.outputs.run-id }}
 
       - name: Check if version already published
         run: |


### PR DESCRIPTION
## Summary

Fixes the release workflow to properly download artifacts from previous workflow runs using the official `actions/download-artifact@v4` action.

## Problem

The `publish-release` job was failing because `actions/download-artifact@v4` by default only downloads artifacts from the same workflow run. When creating a release, it triggers a new workflow run that needs to download artifacts built during the previous master branch push.

## Solution

- Added "Find workflow run for commit" step that queries the GitHub API to find the workflow run ID for the commit SHA
- Updated all download-artifact steps to include:
  - `github-token: ${{ secrets.GITHUB_TOKEN }}` - for cross-run authentication
  - `run-id: ${{ steps.find-run.outputs.run-id }}` - to specify which workflow run to download from

Uses the official GitHub action (no third-party dependencies required).

## Test Plan

- [ ] Merge this PR to master
- [ ] Wait for CI/CD to build artifacts
- [ ] Create release v1.0.0-beta.14
- [ ] Verify artifacts are downloaded and published successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)