### PR TITLE
Disable debug symbols for standalone executables

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -18,7 +18,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <DebugType>portable</DebugType>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/exe/Directory.Build.props
+++ b/exe/Directory.Build.props
@@ -9,5 +9,9 @@
 
     <!-- Suppress NuGet versioning warnings for standalone executables -->
     <NoWarn>$(NoWarn);NU5104</NoWarn>
+
+    <!-- Disable debug symbols for standalone executables -->
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Disable debug symbols (.pdb/.dbg files) for standalone executables to prevent them from being discovered as utilities
- Change Source DebugType from portable to embedded for better source link integration