### PR TITLE
fix: remove ganda dependency from check-version command

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           dotnet-version: '10.0.201'
 
+      - name: Install ganda CLI
+        run: dotnet tool install --global TimeWarp.Ganda --prerelease
+
       - name: NuGet login (OIDC Trusted Publishing)
         if: github.event_name == 'release'
         id: nuget-login

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,9 +43,6 @@ jobs:
         with:
           dotnet-version: '10.0.201'
 
-      - name: Install ganda CLI
-        run: dotnet tool install --global TimeWarp.Ganda --prerelease
-
       - name: NuGet login (OIDC Trusted Publishing)
         if: github.event_name == 'release'
         id: nuget-login

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -5,7 +5,7 @@
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
     <IsPackable>true</IsPackable>
-    <Version>1.0.0-beta.21</Version>
+    <Version>1.0.0-beta.22</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-amuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/tools/dev-cli/endpoints/check-version-command.cs
+++ b/tools/dev-cli/endpoints/check-version-command.cs
@@ -2,8 +2,10 @@
 // Check if the source version matches the git tag
 #endregion
 #region Design
-// Delegates to the ganda CLI to perform the check
+// Reads version from source/Directory.Build.props and compares to git tag
 #endregion
+
+using System.Xml.Linq;
 
 namespace DevCli.Commands;
 
@@ -15,29 +17,87 @@ internal sealed class CheckVersionCommand : ICommand<Unit>
 
   internal sealed class Handler : ICommandHandler<CheckVersionCommand, Unit>
   {
+    private readonly ITerminal Terminal;
+
+    public Handler(ITerminal terminal)
+    {
+      Terminal = terminal;
+    }
+
     public async ValueTask<Unit> Handle(CheckVersionCommand command, CancellationToken ct)
     {
       ArgumentNullException.ThrowIfNull(command);
 
-      List<string> args = ["repo", "check-version", "--strategy", "git-tag"];
-
-      if (!string.IsNullOrEmpty(command.Tag))
+      string? repoRoot = Git.FindRoot();
+      if (repoRoot == null)
       {
-        args.Add("--tag");
-        args.Add(command.Tag);
+        Terminal.WriteErrorLine("❌ Not in a git repository");
+        Environment.ExitCode = 1;
+        return Unit.Value;
       }
 
-      int exitCode = await Shell.Builder("ganda")
-        .WithArguments([.. args])
-        .WithNoValidation()
-        .RunAsync(ct);
-
-      if (exitCode != 0)
+      // Get version from source/Directory.Build.props
+      string propsPath = Path.Combine(repoRoot, "source", "Directory.Build.props");
+      if (!File.Exists(propsPath))
       {
-        Environment.ExitCode = exitCode;
+        Terminal.WriteErrorLine($"❌ Version props not found: {propsPath}");
+        Environment.ExitCode = 1;
+        return Unit.Value;
       }
 
-      return Value;
+      XDocument doc = XDocument.Load(propsPath);
+      string? sourceVersion = doc.Descendants("Version").FirstOrDefault()?.Value;
+
+      if (string.IsNullOrEmpty(sourceVersion))
+      {
+        Terminal.WriteErrorLine("❌ Could not find <Version> in Directory.Build.props");
+        Environment.ExitCode = 1;
+        return Unit.Value;
+      }
+
+      // Get git tag
+      string? gitTag = command.Tag;
+      
+      if (string.IsNullOrEmpty(gitTag))
+      {
+        // Try GITHUB_REF_NAME first (set by GitHub Actions for releases)
+        gitTag = Environment.GetEnvironmentVariable("GITHUB_REF_NAME");
+        
+        // Remove 'v' prefix if present
+        if (!string.IsNullOrEmpty(gitTag) && gitTag.StartsWith('v'))
+        {
+          gitTag = gitTag[1..];
+        }
+      }
+
+      if (string.IsNullOrEmpty(gitTag))
+      {
+        // Fall back to git describe
+        CommandOutput result = await Shell.Builder("git")
+          .WithArguments("describe", "--tags", "--abbrev=0")
+          .CaptureAsync(ct);
+        
+        gitTag = result.Stdout.Trim();
+        if (!string.IsNullOrEmpty(gitTag) && gitTag.StartsWith('v'))
+        {
+          gitTag = gitTag[1..];
+        }
+      }
+
+      Terminal.WriteLine($"Source version: {sourceVersion}");
+      Terminal.WriteLine($"Git tag:        {gitTag}");
+
+      if (sourceVersion == gitTag)
+      {
+        Terminal.WriteLine("✅ Version matches git tag");
+        return Unit.Value;
+      }
+      else
+      {
+        Terminal.WriteErrorLine($"❌ Version mismatch: source={sourceVersion}, tag={gitTag}");
+        Environment.ExitCode = 1;
+        return Unit.Value;
+      }
     }
   }
 }

--- a/tools/dev-cli/endpoints/workflow-command.cs
+++ b/tools/dev-cli/endpoints/workflow-command.cs
@@ -152,7 +152,7 @@ internal sealed class WorkflowCommand : ICommand<Unit>
       Terminal.WriteLine("===============================================================================");
       Terminal.WriteLine("  Step 3/4: Check Version");
       Terminal.WriteLine("===============================================================================");
-      CheckVersionCommand.Handler checkVersionHandler = new();
+      CheckVersionCommand.Handler checkVersionHandler = new(Terminal);
       await checkVersionHandler.Handle(new CheckVersionCommand(), CancellationToken.None);
 
       Terminal.WriteLine("");


### PR DESCRIPTION
Rewrite check-version to read version directly from Directory.Build.props and compare to git tag, eliminating the ganda CLI dependency.