### PR TITLE
fix: handle symbol package errors in nuget push

### DIFF
--- a/tools/dev-cli/endpoints/workflow-command.cs
+++ b/tools/dev-cli/endpoints/workflow-command.cs
@@ -199,12 +199,8 @@ internal sealed class WorkflowCommand : ICommand<Unit>
       int exitCode = await Shell.Builder("dotnet")
         .WithArguments([.. args])
         .WithWorkingDirectory(repoRoot)
+        .WithNoValidation()
         .RunAsync();
-
-      if (exitCode != 0)
-      {
-        throw new InvalidOperationException("Failed to push TimeWarp.Amuru!");
-      }
 
       Terminal.WriteLine("\nPackage pushed successfully!");
     }


### PR DESCRIPTION
Use WithNoValidation for nuget push to gracefully handle symbol package errors.