### PR TITLE
chore: bump version to 1.0.0-beta.26

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -5,7 +5,7 @@
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
     <IsPackable>true</IsPackable>
-    <Version>1.0.0-beta.25</Version>
+    <Version>1.0.0-beta.26</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-amuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Bump version to 1.0.0-beta.26 for release.

The previous release failed because the version bump wasn't included in PR #67.

## Files Changed

- `source/Directory.Build.props` - Version: 1.0.0-beta.25 → 1.0.0-beta.26