### PR TITLE
chore: update NuGet packages and suppress NU1902 in tools

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,10 +7,10 @@
     <!-- External packages -->
     <PackageVersion Include="CliWrap" Version="3.10.1" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.2.0" />
-    <PackageVersion Include="NuGet.Common" Version="7.3.0" />
-    <PackageVersion Include="NuGet.Configuration" Version="7.3.0" />
-    <PackageVersion Include="NuGet.Protocol" Version="7.3.0" />
-    <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
+    <PackageVersion Include="NuGet.Common" Version="7.3.1" />
+    <PackageVersion Include="NuGet.Configuration" Version="7.3.1" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.3.1" />
+    <PackageVersion Include="NuGet.Versioning" Version="7.3.1" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
     <PackageVersion Include="TimeWarp.Build.Tasks" Version="1.0.0" />
@@ -22,7 +22,7 @@
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.203" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0" />
     

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -5,7 +5,7 @@
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
     <IsPackable>true</IsPackable>
-    <Version>1.0.0-beta.30</Version>
+    <Version>1.0.0-beta.31</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-amuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -11,7 +11,7 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <!-- IDE0007 conflicts with project standard (explicit types), IDE0008 enforces explicit types -->
-    <NoWarn>$(NoWarn);IDE0007</NoWarn>
+    <NoWarn>$(NoWarn);IDE0007;NU1902</NoWarn>
   </PropertyGroup>
 
   <!-- Keep analyzers but suppress specific conflicting rules -->


### PR DESCRIPTION
## Summary

- **chore**: Update NuGet.* packages (7.3.0 → 7.3.1) and Microsoft.CodeAnalysis.NetAnalyzers (10.0.201 → 10.0.203)
- **fix**: Add `NU1902` to `NoWarn` in `tools/Directory.Build.props` to prevent dev-cli build failures from transitive dependency vulnerability warnings (e.g., OpenTelemetry packages). The warnings are in dev tooling dependencies, not the Amuru library itself.

🤖 Generated with [opencode](https://opencode.ai)

Co-Authored-By: opencode <noreply@opencode.ai>