### PR TITLE
Fix release-run test failures: env resolution moved to CLI edge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ This file provides guidance to agents when working with code in this repository.
 - **Tool-wrapper construction**: builders create commands via the public `Shell.Run(executable, args, options, stdin)` — never via core internals (no InternalsVisibleTo)
 - **C# script execution**: `.cs` files get `--` prefix inserted before arguments to prevent dotnet interception; on Windows they route through the `dotnet` host
 - **Tests that change CurrentDirectory must restore it** (try/finally) — later tests in the aggregate run depend on running inside the repo
+- **Runfile caches can serve STALE ProjectReference builds**: after editing library source, `dotnet run <test>.cs` may run against an old copy of the referenced project. If test behavior contradicts the source you just changed, clear the cache: `rm -rf ~/.local/share/dotnet/runfile/<test-name>-*`
 - **Analyzer overrides**: Different analyzer settings in `tests/`, `samples/` directories; `source/.editorconfig` adds CA2007 for the library projects
 
 ## Code Style Rules

--- a/source/timewarp-amuru-tools/repo/IRepoCheckVersionService.cs
+++ b/source/timewarp-amuru-tools/repo/IRepoCheckVersionService.cs
@@ -34,7 +34,7 @@ public interface IRepoCheckVersionService
   /// <summary>
   /// Checks if the current version is new compared to git tags.
   /// </summary>
-  /// <param name="tag">Specific tag to check (optional, uses GITHUB_REF_NAME or latest git tag if not provided)</param>
+  /// <param name="tag">Specific tag to check (optional; falls back to the latest git tag). Callers resolve environment refs like GITHUB_REF_NAME themselves.</param>
   /// <param name="cancellationToken">Cancellation token</param>
   /// <returns>The result of the git tag version check</returns>
   Task<GitTagCheckResult> CheckGitTagVersionAsync(string? tag = null, CancellationToken cancellationToken = default);

--- a/source/timewarp-amuru-tools/repo/RepoCheckVersionService.cs
+++ b/source/timewarp-amuru-tools/repo/RepoCheckVersionService.cs
@@ -36,17 +36,10 @@ public sealed class RepoCheckVersionService : IRepoCheckVersionService
 
     string? latestTag = tag;
 
-    if (string.IsNullOrWhiteSpace(latestTag))
-    {
-      // GITHUB_REF_NAME is only a tag on tag-triggered runs; on PR/push runs it is a
-      // branch name ("81/merge", "master") and must not be treated as a release tag.
-      string? refType = Environment.GetEnvironmentVariable("GITHUB_REF_TYPE");
-      if (string.Equals(refType, "tag", StringComparison.OrdinalIgnoreCase))
-      {
-        latestTag = Environment.GetEnvironmentVariable("GITHUB_REF_NAME");
-      }
-    }
-
+    // Environment resolution (e.g. GITHUB_REF_NAME on tag-triggered CI runs) is the
+    // CALLER's job via the explicit tag parameter; peeking env vars here made the
+    // service behave differently under CI than anywhere else and untestable on
+    // release runs.
     if (string.IsNullOrWhiteSpace(latestTag))
     {
       latestTag = await GetLatestGitTagAsync(cancellationToken).ConfigureAwait(false);

--- a/tools/dev-cli/endpoints/check-version-command.cs
+++ b/tools/dev-cli/endpoints/check-version-command.cs
@@ -50,7 +50,7 @@ internal sealed class CheckVersionCommand : ICommand<Unit>
       {
         GitTagCheckResult result = await repoCheckVersionService.CheckGitTagVersionAsync
         (
-          tag: command.Tag,
+          tag: command.Tag ?? ResolveTagFromEnvironment(),
           cancellationToken: ct
         );
 
@@ -83,6 +83,16 @@ internal sealed class CheckVersionCommand : ICommand<Unit>
       }
 
       return Unit.Value;
+    }
+
+    // GITHUB_REF_NAME is only a tag on tag-triggered runs; on PR/push runs it is a
+    // branch name ("81/merge", "master") and must not be treated as a release tag.
+    private static string? ResolveTagFromEnvironment()
+    {
+      string? refType = Environment.GetEnvironmentVariable("GITHUB_REF_TYPE");
+      return string.Equals(refType, "tag", StringComparison.OrdinalIgnoreCase)
+        ? Environment.GetEnvironmentVariable("GITHUB_REF_NAME")
+        : null;
     }
 
     private void WriteGitTagOutput(GitTagCheckResult result)


### PR DESCRIPTION
The v1.0.0-beta.35 release run failed in the test step: with GITHUB_REF_TYPE=tag set, RepoCheckVersionService preferred the ambient ref over its git-tag lookup, so the mocked-git tests failed exactly (and only) in the release environment.

The service is now environment-free — the dev-cli check-version command resolves GITHUB_REF_NAME (only for tag-typed refs) and passes it through the existing explicit `tag` parameter. Full suite verified green under plain, PR-run (`GITHUB_REF_TYPE=branch`), and release-run (`GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.0.0-beta.35`) environments.

After merge, the v1.0.0-beta.35 release/tag needs to be recreated against the new master so the pipeline reruns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)