### PR TITLE
refactor(skills): prefix owned skill with tw- for invoke filtering

### DIFF
--- a/kanban/done/111-prefix-amuru-skill-with-tw-for-invoke-filtering.md
+++ b/kanban/done/111-prefix-amuru-skill-with-tw-for-invoke-filtering.md
@@ -17,7 +17,7 @@ Rename the owned Amuru skill `skills/amuru` → `skills/tw-amuru` (folder + fron
 - [x] `git mv` skill folder and set frontmatter `name: tw-amuru`
 - [x] Grep-clean live refs (`skills/amuru`, `name: amuru`) excluding `kanban/done/**`
 - [x] Reset of local master worktree is orchestrator-owned (do not do it)
-- [ ] PR opened to `dev` (orchestrator-owned if you do not open it)
+- [x] PR opened to `dev` (orchestrator-owned if you do not open it)
 
 ## Notes
 

--- a/kanban/done/111-prefix-amuru-skill-with-tw-for-invoke-filtering.md
+++ b/kanban/done/111-prefix-amuru-skill-with-tw-for-invoke-filtering.md
@@ -37,3 +37,4 @@ Rename the owned Amuru skill `skills/amuru` → `skills/tw-amuru` (folder + fron
 - Live refs clean; historical `kanban/done/068-*` left alone
 - Local master worktree reset to `origin/master` (`c109775`); no longer ahead/behind
 - `ganda skills add tw-amuru` now resolves to this feature worktree; re-point to `…/master/skills/tw-amuru` after the rename is on master
+- PR: https://github.com/TimeWarpEngineering/timewarp-amuru/pull/84

--- a/kanban/in-progress/111-prefix-amuru-skill-with-tw-for-invoke-filtering.md
+++ b/kanban/in-progress/111-prefix-amuru-skill-with-tw-for-invoke-filtering.md
@@ -1,0 +1,29 @@
+# Prefix amuru skill with tw- for invoke filtering
+
+## Description
+
+Rename the owned Amuru skill `skills/amuru` → `skills/tw-amuru` (folder + frontmatter `name:`) so it matches the TimeWarp ownership prefix policy (flow task 092). A Jul 18 commit (`cb6dec3`) did this on the local master worktree and was never pushed; redo it on a feature branch from origin/dev.
+
+## Requirements
+
+- Folder `skills/tw-amuru/SKILL.md` exists; `skills/amuru/` is gone
+- Frontmatter `name: tw-amuru`
+- Live references to `skills/amuru` updated (leave historical `kanban/done/**` alone)
+- Work is on `Cramer/2026-08-15/Prefix_Amuru_Skill`, never on local master
+
+## Checklist
+
+- [ ] Create this task via `ganda kanban create` and commit
+- [ ] `git mv` skill folder and set frontmatter `name: tw-amuru`
+- [ ] Grep-clean live refs (`skills/amuru`, `name: amuru`) excluding `kanban/done/**`
+- [ ] Reset of local master worktree is orchestrator-owned (do not do it)
+- [ ] PR opened to `dev` (orchestrator-owned if you do not open it)
+
+## Notes
+
+- Cherry-pick source: `cb6dec3` (local master only) — same 1-line frontmatter change + rename
+- Ganda SkillSource currently: `worktree://github.com/TimeWarpEngineering/timewarp-amuru/master/skills/tw-amuru` (orchestrator will re-point)
+
+## Session
+
+- Implementation: Grok 2026-08-15

--- a/kanban/in-progress/111-prefix-amuru-skill-with-tw-for-invoke-filtering.md
+++ b/kanban/in-progress/111-prefix-amuru-skill-with-tw-for-invoke-filtering.md
@@ -16,17 +16,18 @@ Rename the owned Amuru skill `skills/amuru` → `skills/tw-amuru` (folder + fron
 - [x] Create this task via `ganda kanban create` and commit
 - [x] `git mv` skill folder and set frontmatter `name: tw-amuru`
 - [x] Grep-clean live refs (`skills/amuru`, `name: amuru`) excluding `kanban/done/**`
-- [ ] Reset of local master worktree is orchestrator-owned (do not do it)
+- [x] Reset of local master worktree is orchestrator-owned (do not do it)
 - [ ] PR opened to `dev` (orchestrator-owned if you do not open it)
 
 ## Notes
 
 - Cherry-pick source: `cb6dec3` (local master only) — same 1-line frontmatter change + rename
-- Ganda SkillSource currently: `worktree://github.com/TimeWarpEngineering/timewarp-amuru/master/skills/tw-amuru` (orchestrator will re-point)
+- Ganda SkillSource re-pointed to this feature worktree until the rename exists on master again
 
 ## Session
 
 - Implementation: Grok 2026-08-15
+- Orchestrator: Grok 2026-08-15 — reset local master to origin/master; re-point ganda tw-amuru source
 
 ## Results
 
@@ -34,4 +35,5 @@ Rename the owned Amuru skill `skills/amuru` → `skills/tw-amuru` (folder + fron
 - `skills/amuru` → `skills/tw-amuru`; frontmatter `name: tw-amuru`
 - Left `BannedSymbols.txt` ban-message text unchanged (ganda exact-rule audit)
 - Live refs clean; historical `kanban/done/068-*` left alone
-- Master reset and PR left to orchestrator
+- Local master worktree reset to `origin/master` (`c109775`); no longer ahead/behind
+- `ganda skills add tw-amuru` now resolves to this feature worktree; re-point to `…/master/skills/tw-amuru` after the rename is on master

--- a/kanban/in-progress/111-prefix-amuru-skill-with-tw-for-invoke-filtering.md
+++ b/kanban/in-progress/111-prefix-amuru-skill-with-tw-for-invoke-filtering.md
@@ -13,9 +13,9 @@ Rename the owned Amuru skill `skills/amuru` → `skills/tw-amuru` (folder + fron
 
 ## Checklist
 
-- [ ] Create this task via `ganda kanban create` and commit
-- [ ] `git mv` skill folder and set frontmatter `name: tw-amuru`
-- [ ] Grep-clean live refs (`skills/amuru`, `name: amuru`) excluding `kanban/done/**`
+- [x] Create this task via `ganda kanban create` and commit
+- [x] `git mv` skill folder and set frontmatter `name: tw-amuru`
+- [x] Grep-clean live refs (`skills/amuru`, `name: amuru`) excluding `kanban/done/**`
 - [ ] Reset of local master worktree is orchestrator-owned (do not do it)
 - [ ] PR opened to `dev` (orchestrator-owned if you do not open it)
 
@@ -27,3 +27,11 @@ Rename the owned Amuru skill `skills/amuru` → `skills/tw-amuru` (folder + fron
 ## Session
 
 - Implementation: Grok 2026-08-15
+
+## Results
+
+- Cherry-picked `cb6dec3` cleanly as `5a02a88` (`refactor(skills): prefix owned skill with tw- for invoke filtering`)
+- `skills/amuru` → `skills/tw-amuru`; frontmatter `name: tw-amuru`
+- Left `BannedSymbols.txt` ban-message text unchanged (ganda exact-rule audit)
+- Live refs clean; historical `kanban/done/068-*` left alone
+- Master reset and PR left to orchestrator

--- a/skills/tw-amuru/SKILL.md
+++ b/skills/tw-amuru/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: amuru
+name: tw-amuru
 description: Use TimeWarp.Amuru for process execution instead of System.Diagnostics.Process
 ---
 


### PR DESCRIPTION
## Summary

- Rename the owned Amuru skill `skills/amuru` → `skills/tw-amuru` (folder + frontmatter `name: tw-amuru`) so it matches the TimeWarp ownership prefix (flow task 092 / `/tw` invoke filter).
- A 18 Jul commit (`cb6dec3`) did this on the **local master worktree** and was never pushed. Local master is reset to `origin/master`. This branch redoes the rename from `origin/dev`.
- Kanban task **111**.

## Test plan

- [x] `skills/tw-amuru/SKILL.md` has `name: tw-amuru`; `skills/amuru/` is gone
- [x] Live refs grep-clean (historical `kanban/done/068-*` left alone)
- [x] Local master worktree: `git status` is even with `origin/master` (not ahead/behind)
- [ ] After merge: `ganda skills add tw-amuru worktree://github.com/TimeWarpEngineering/timewarp-amuru/master/skills/tw-amuru` and `ganda skills update tw-amuru` (source currently points at this feature worktree)

## Audit

`ganda repo audit` is **not** clean on this branch. Same 4 failures as current `origin/dev` / the `dev` worktree — not introduced by this change:

- `bin-dev` / `dev-cli-capabilities` — `bin/dev` missing (local install artifact)
- `nuget-package-urls` — `source/Directory.Build.props` missing `<PackageProjectUrl>`
- `nuru` — TimeWarp.Nuru `3.0.0-beta.72` < latest `3.0.0-beta.76`

No version bump: docs/skill/kanban only.