### PR TITLE
chore(kanban): archive 028 as superseded by 094

### DIFF
--- a/kanban/archived/028-implement-cli-utilities-as-native-commands.md
+++ b/kanban/archived/028-implement-cli-utilities-as-native-commands.md
@@ -1,3 +1,9 @@
+> **ARCHIVED 2026-09-04:** superseded by task 094 (1.0 public API surface).
+> CLI utilities were implemented in Amuru, then removed or moved: 094-001 deleted
+> Post / GenerateColor / ConvertTimestamp / Installer; 094-002 moved SshKeyHelper
+> to Zana. Remaining distribution work belongs in ganda / Zana / Kijamii (031/033),
+> not Amuru. GitHub issue #14 left open for retarget.
+
 # 028 Implement CLI Utilities As Native Commands
 
 ## Description
@@ -243,3 +249,7 @@ Available source files:
 - Existing private repo implementations
 - .NET Tool documentation: https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools
 - PublishAot documentation: https://docs.microsoft.com/en-us/dotnet/core/deploying/native-aot
+
+## Session
+
+- Archived: 01a06a4a-807d-7143-9d21-330f32238619 (2026-09-04) — cockpit archive; Amuru is no longer the home for these utilities after 094.


### PR DESCRIPTION
## Summary
- Archive kanban task 028 (Implement CLI Utilities As Native Commands).
- Amuru is no longer the home for those utilities after the 1.0 surface cut: 094-001 deleted Post / GenerateColor / ConvertTimestamp / Installer; 094-002 moved SshKeyHelper to Zana.
- Leftover distribution work belongs in ganda / Zana / Kijamii (031/033), not this card.
- GitHub issue #14 left open for retarget.

Kanban-only. `ganda kanban publish` cannot land this (publish requires kitchen in `to-do/`).

## Test plan
- [x] Diff is one file: `kanban/{in-progress => archived}/028-implement-cli-utilities-as-native-commands.md`
- [x] `ganda repo audit` is red on this branch with the same pre-existing failures as origin/master (not introduced here)
- [ ] After merge, `ganda kanban board TimeWarpEngineering/timewarp-amuru --show-archived` lists 028 in archived
- [ ] Origin-home in-progress column no longer includes 028
